### PR TITLE
ECONNRESET hangs

### DIFF
--- a/securegateway_troubleshooting.md
+++ b/securegateway_troubleshooting.md
@@ -29,7 +29,13 @@ Error | Typical Cause | Troubleshooting Methods
 --- | --- | ---
 ETIMEDOUT | The client is unable to find the hostname/ip to connect to due to network constraints. | Attempt to ping the destination's hostname/ip from the host running the client to ensure network connectivity.  If running the Docker version of the client, bridging the container with the host OS  with `--net=host` may resolve the issue.
 ECONNREFUSED | The client has resolved the hostname/ip to connect to but is unable to begin the connection handshake | This is typically caused by a mismatched protocol between the SG Client and the on-prem resource (e.g., the client is attempting a TCP connection to a host:port that is expecting a TLS connection).  In some cases, a firewall rule may cause this error instead of ETIMEDOUT.
-ECONNRESET | The client has established a connection to the destination but something went wrong either during the handshake (a TLS handshake error might result in different errors, as well) or while the request was being handled by the on-prem resource. | The logs of the on-prem resource should be checked to confirm no error has caused the connection to be interrupted.  If nothing is found in the on-prem logs, then the destination configuration should be examined to ensure the appropriate protocols (and certificates, if necessary) are being provided to the client for the connection.
+ECONNRESET | The client has established a connection to the destination but something went wrong either during the handshake (a TLS handshake error might result in different errors, as well) or while the request was being handled by the on-prem resource. | The logs of the on-prem resource should be checked to confirm no error has caused the connection to be interrupted.  If nothing is found in the on-prem logs, then the destination configuration should be examined to ensure the appropriate protocols (and certificates, if necessary) are being provided to the client for the connection. 
+
+Many applications experience "hangs" after an ECONNRESET occurring on the other end of the tunnel. This is expected. Secure 
+Gateway can not replay the RST packet on the other end of the tunnel since the TCP packets have already been ACKed for that
+side of the tunnel. Application level timeouts, the application never receives an acknowledging response, are the only
+method to end the hang.
+
 
 ## Configure your Docker client to restart when your server restarts
 {: #docker}


### PR DESCRIPTION
many customers complain about hangs after ECONNRESETs.
This explains why hangs are unavoidable and how to mitigate impact.